### PR TITLE
Add Drip signup integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,9 @@ VITE_STRIPE_PRICE_ID=your_product_price_id
 # Additional Configuration
 # Add any other environment variables your application needs here
 # FORMAT: VARIABLE_NAME=example_value
+
+# Drip integration
+DRIP_ACCOUNT_ID=your_drip_account_id
+DRIP_API_TOKEN=your_drip_api_token
+# URL of the Supabase Edge Function that syncs signups to Drip
+VITE_DRIP_FUNCTION_URL=https://your-project-ref.functions.supabase.co/sync-to-drip

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
    - `VITE_SUPABASE_ANON_KEY`
    - `VITE_STRIPE_PUBLIC_KEY`
    - `VITE_STRIPE_PRICE_ID`
+   - `DRIP_ACCOUNT_ID`
+   - `DRIP_API_TOKEN`
+   - `VITE_DRIP_FUNCTION_URL`
 
 Note: Never commit sensitive API keys to the repository. Always use environment variables for sensitive data.
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -74,7 +74,9 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
-  const signUp = async (email, password) => {
+  const DRIP_FUNCTION_URL = import.meta.env.VITE_DRIP_FUNCTION_URL
+
+  const signUp = async (email, password, fullName) => {
     try {
       console.log('Starting sign-up process for:', email);
       
@@ -96,6 +98,7 @@ export const AuthProvider = ({ children }) => {
         options: {
           emailRedirectTo: `${window.location.origin}/auth/callback`,
           data: {
+            full_name: fullName,
             email_confirm: false
           }
         }
@@ -111,6 +114,25 @@ export const AuthProvider = ({ children }) => {
       if (!data.user) {
         console.error('No user data returned');
         throw new Error('Failed to create user account');
+      }
+
+      if (DRIP_FUNCTION_URL) {
+        try {
+          await fetch(
+            DRIP_FUNCTION_URL,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                email,
+                name: fullName,
+                sourceApp: 'Prompt Array'
+              })
+            }
+          )
+        } catch (syncError) {
+          console.error('Drip sync error:', syncError)
+        }
       }
 
       // Check if email confirmation is required

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -14,10 +14,12 @@ const Register = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
+      const fullNameInput = e.target.querySelector('#fullName');
       const emailInput = e.target.querySelector('#email');
       const passwordInput = e.target.querySelector('#password');
       const confirmPasswordInput = e.target.querySelector('#confirmPassword');
 
+      const fullName = fullNameInput?.value;
       const email = emailInput?.value;
       const password = passwordInput?.value;
       const confirmPassword = confirmPasswordInput?.value;
@@ -33,7 +35,7 @@ const Register = () => {
       }
 
       console.log('Starting registration for:', email);
-      const { data, requiresEmailConfirmation } = await signUp(email, password);
+      const { data, requiresEmailConfirmation } = await signUp(email, password, fullName);
       
       if (requiresEmailConfirmation) {
         // Store email for resend functionality

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -24,7 +24,7 @@ const SignIn = () => {
     
     try {
       if (isSignUp) {
-        await signUp(formData.email, formData.password);
+        await signUp(formData.email, formData.password, undefined);
         navigate(redirectPath);
       } else {
         await signIn(formData.email, formData.password);

--- a/supabase/functions/sync-to-drip/index.ts
+++ b/supabase/functions/sync-to-drip/index.ts
@@ -1,0 +1,28 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+
+const ACCOUNT = Deno.env.get("DRIP_ACCOUNT_ID")
+const TOKEN   = Deno.env.get("DRIP_API_TOKEN")
+
+serve(async req => {
+  const { email, name, sourceApp } = await req.json()
+
+  await fetch(
+    `https://api.getdrip.com/v2/${ACCOUNT}/subscribers`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Token token=${TOKEN}`
+      },
+      body: JSON.stringify({
+        subscribers: [{
+          email,
+          first_name: name,
+          tags: [sourceApp]
+        }]
+      })
+    }
+  )
+
+  return new Response("ok")
+})


### PR DESCRIPTION
## Summary
- add `sync-to-drip` edge function to push signups to Drip
- wire Drip call into signup flow
- pass full name to sign up
- document Drip environment variables

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*