### PR TITLE
Add CORS headers to drip sync function

### DIFF
--- a/supabase/functions/sync-to-drip/index.ts
+++ b/supabase/functions/sync-to-drip/index.ts
@@ -3,7 +3,17 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 const ACCOUNT = Deno.env.get("DRIP_ACCOUNT_ID")
 const TOKEN   = Deno.env.get("DRIP_API_TOKEN")
 
-serve(async req => {
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders })
+  }
+
   const { email, name, sourceApp } = await req.json()
 
   await fetch(
@@ -24,5 +34,5 @@ serve(async req => {
     }
   )
 
-  return new Response("ok")
+  return new Response("ok", { headers: corsHeaders })
 })


### PR DESCRIPTION
## Summary
- handle CORS preflight for `sync-to-drip` function
- keep Drip signup call in `AuthContext` intact

## Testing
- `npm run lint` *(fails: ESLint couldn't find config and dependencies)*
- `npm run build` *(fails: vite not found)*